### PR TITLE
restrict tf cicd to specific paths

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -4,6 +4,9 @@ permissions:
 
 on:
   push:
+    paths:
+      - 'terraform/**'
+      - 'scripts/deployment/**'
 
 env:
   PM_API_TOKEN_ID: ${{ vars.PM_API_TOKEN_ID }}


### PR DESCRIPTION
This is a minor change to update the Terraform CI/CD to only run on file path changes to:

- terraform/
- scripts/deployment/