### PR TITLE
feat: add win vm to lab

### DIFF
--- a/terraform/deployments/lab/env/lab/terraform.tfvars
+++ b/terraform/deployments/lab/env/lab/terraform.tfvars
@@ -38,4 +38,5 @@ windows11 = {
   memory_mb      = 16384
   os_disk_size   = 64
   network_bridge = "vmbr0"
+  vlan_id        = 99
 }

--- a/terraform/deployments/lab/env/lab/terraform.tfvars
+++ b/terraform/deployments/lab/env/lab/terraform.tfvars
@@ -30,3 +30,12 @@ pwnbox = {
   vlan_id        = 200
   admin_username = "krkn"
 }
+windows11 = {
+  name_prefix    = "win11"
+  description    = "Windows 11 - Managed by Terraform"
+  tags           = ["windows"]
+  cpu_cores      = 4
+  memory_mb      = 16384
+  os_disk_size   = 64
+  network_bridge = "vmbr0"
+}

--- a/terraform/deployments/lab/main.tf
+++ b/terraform/deployments/lab/main.tf
@@ -98,6 +98,7 @@ resource "proxmox_virtual_environment_vm" "windows11" {
     type    = "host"
     cores   = var.windows11.cpu_cores
     sockets = 1
+    flags   = ["+vmx"]
   }
 
   memory {

--- a/terraform/deployments/lab/main.tf
+++ b/terraform/deployments/lab/main.tf
@@ -67,3 +67,92 @@ module "pwnbox" {
   vm_network_bridge              = var.pwnbox.network_bridge
   vm_vlan_id                     = var.pwnbox.vlan_id
 }
+
+# -----------------------------------------------------------------------------
+# Windows 11 VM
+# -----------------------------------------------------------------------------
+# Uses a raw resource instead of the cloud-init module since Windows requires
+# ISO-based installation with UEFI, TPM 2.0, and VirtIO driver loading.
+# Post-apply steps:
+#   1. Attach virtio-win.iso as a second CD-ROM via Proxmox UI (Hardware > Add > CD/DVD)
+#   2. Boot the VM and install Windows via the Proxmox console
+#   3. During disk selection, load driver: vioscsi\w11\amd64 from the VirtIO CD
+#   4. After install, run virtio-win-gt-x64.msi from the VirtIO CD for all drivers + QEMU Guest Agent
+
+resource "proxmox_virtual_environment_vm" "windows11" {
+  provider = pve
+
+  name        = var.windows11.name_prefix
+  node_name   = var.pve.host
+  description = var.windows11.description
+  tags        = sort(concat(["terraform"], var.windows11.tags))
+  on_boot     = false
+  bios        = "ovmf"
+  machine     = "q35"
+
+  operating_system {
+    type = "win11"
+  }
+
+  cpu {
+    type    = "host"
+    cores   = var.windows11.cpu_cores
+    sockets = 1
+  }
+
+  memory {
+    dedicated = var.windows11.memory_mb
+    floating  = 0
+  }
+
+  tpm_state {
+    version      = "v2.0"
+    datastore_id = var.vm_disk_datastore_id
+  }
+
+  efi_disk {
+    datastore_id      = var.vm_disk_datastore_id
+    file_format       = "raw"
+    type              = "4m"
+    pre_enrolled_keys = true
+  }
+
+  # OS disk — VirtIO SCSI for best performance
+  disk {
+    interface    = "scsi0"
+    datastore_id = var.vm_disk_datastore_id
+    size         = var.windows11.os_disk_size
+    file_format  = "raw"
+    cache        = "writeback"
+    discard      = "on"
+    iothread     = true
+    ssd          = true
+  }
+
+  scsi_hardware = "virtio-scsi-single"
+
+  # Windows 11 installation ISO
+  cdrom {
+    file_id   = "local:iso/win11-latest.iso"
+    interface = "ide0"
+  }
+
+  agent {
+    enabled = true
+    type    = "virtio"
+    trim    = true
+  }
+
+  network_device {
+    model   = "virtio"
+    bridge  = var.windows11.network_bridge
+    vlan_id = var.windows11.vlan_id
+  }
+
+  vga {
+    type   = "virtio"
+    memory = 64
+  }
+
+  stop_on_destroy = true
+}

--- a/terraform/deployments/lab/main.tf
+++ b/terraform/deployments/lab/main.tf
@@ -98,7 +98,7 @@ resource "proxmox_virtual_environment_vm" "windows11" {
     type    = "host"
     cores   = var.windows11.cpu_cores
     sockets = 1
-    flags   = ["+vmx"]
+    flags   = ["+nested-virt"]
   }
 
   memory {

--- a/terraform/deployments/lab/variables.tf
+++ b/terraform/deployments/lab/variables.tf
@@ -48,12 +48,27 @@ variable "pwnbox" {
     tags           = optional(list(string), ["ctf"])
     bios           = optional(string, "ovmf")
     cpu_cores      = optional(number, 4)
-    memory_mb      = optional(number, 8192)
+    memory_mb      = optional(number, 16384)
     os_disk_size   = optional(number, 50)
     disk_interface = optional(string, "virtio0")
     network_bridge = optional(string, "vmbr0")
     vlan_id        = optional(number, 200)
     admin_username = optional(string, "krkn")
+  })
+  default = {}
+}
+
+variable "windows11" {
+  description = "Object containing the Windows 11 VM configuration"
+  type = object({
+    name_prefix    = optional(string, "win11")
+    description    = optional(string, "Windows 11 - Managed by Terraform")
+    tags           = optional(list(string), ["windows"])
+    cpu_cores      = optional(number, 4)
+    memory_mb      = optional(number, 8192)
+    os_disk_size   = optional(number, 64)
+    network_bridge = optional(string, "vmbr0")
+    vlan_id        = optional(number, null)
   })
   default = {}
 }


### PR DESCRIPTION
This pull request introduces support for provisioning a Windows 11 virtual machine (VM) in the lab environment using Terraform, alongside some configuration updates for existing resources. The most significant changes are the addition of a new Windows 11 VM resource, the corresponding variable definitions, and an update to the default memory allocation for the `pwnbox` VM.

**Windows 11 VM provisioning:**

* Added a new `windows11` variable object in `variables.tf` to define configuration options for the Windows 11 VM, including CPU, memory, disk size, and network settings.
* Created a new `windows11` resource block in `main.tf` using `proxmox_virtual_environment_vm` to provision a Windows 11 VM with UEFI, TPM 2.0, VirtIO drivers, and detailed post-apply instructions for manual steps required during OS installation.
* Added a `windows11` configuration block in `terraform.tfvars` to specify the default values for the new VM.

**Configuration updates:**

* Increased the default memory allocation for the `pwnbox` VM from 8192 MB to 16384 MB in `variables.tf` for improved performance.
