### PR TITLE
feat: cmd_and_ctrl game server

### DIFF
--- a/.github/workflows/lab-deploy.yaml
+++ b/.github/workflows/lab-deploy.yaml
@@ -7,18 +7,18 @@ permissions:
 on:
   push:
     paths:
-      - 'terraform/deployments/lab/**'
-      - '.github/workflows/lab.yaml'
-      - '.github/workflows/terraform-ci.yaml'
-      - '.github/workflows/terraform-cd.yaml'
+      - "terraform/deployments/lab/**"
+      - ".github/workflows/lab.yaml"
+      - ".github/workflows/terraform-ci.yaml"
+      - ".github/workflows/terraform-cd.yaml"
     branches:
       - main
   pull_request:
     paths:
-      - 'terraform/deployments/lab/**'
-      - '.github/workflows/lab.yaml'
-      - '.github/workflows/terraform-ci.yaml'
-      - '.github/workflows/terraform-cd.yaml'
+      - "terraform/deployments/lab/**"
+      - ".github/workflows/lab.yaml"
+      - ".github/workflows/terraform-ci.yaml"
+      - ".github/workflows/terraform-cd.yaml"
 
 env:
   PROXMOX_VE_API_TOKEN: ${{ secrets.PROXMOX_VE_API_TOKEN }}
@@ -28,13 +28,16 @@ jobs:
     strategy:
       matrix:
         environment: ["lab"]
-    uses: krakenhavoc/HomeLab/.github/workflows/terraform-ci.yaml@v0.2.0
+    uses: ./.github/workflows/terraform-ci.yaml
     with:
       working_directory: terraform/deployments/lab
       var_file_path: env/${{ matrix.environment }}/terraform.tfvars
       environment: ${{ matrix.environment }}
       runner: self-hosted
       enable_proxmox_ssh: true
+      terraform_vars: >-
+        -var=cmd_and_ctrl_admin_token=${{ secrets.CMD_AND_CTRL_ADMIN_TOKEN }}
+        -var=cmd_and_ctrl_tunnel_token=${{ secrets.CMD_AND_CTRL_TUNNEL_TOKEN }}
     secrets:
       hcp_api_token: ${{ secrets.HCP_API_TOKEN }}
       proxmox_ve_api_token: ${{ secrets.PROXMOX_VE_API_TOKEN }}

--- a/.github/workflows/lab-deploy.yaml
+++ b/.github/workflows/lab-deploy.yaml
@@ -35,12 +35,11 @@ jobs:
       environment: ${{ matrix.environment }}
       runner: self-hosted
       enable_proxmox_ssh: true
-      terraform_vars: >-
-        -var=cmd_and_ctrl_admin_token=${{ secrets.CMD_AND_CTRL_ADMIN_TOKEN }}
-        -var=cmd_and_ctrl_tunnel_token=${{ secrets.CMD_AND_CTRL_TUNNEL_TOKEN }}
     secrets:
       hcp_api_token: ${{ secrets.HCP_API_TOKEN }}
       proxmox_ve_api_token: ${{ secrets.PROXMOX_VE_API_TOKEN }}
+      cmd_and_ctrl_admin_token: ${{ secrets.CMD_AND_CTRL_ADMIN_TOKEN }}
+      cmd_and_ctrl_tunnel_token: ${{ secrets.CMD_AND_CTRL_TUNNEL_TOKEN }}
 
   lab-cd:
     needs: lab-ci

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -50,6 +50,12 @@ on:
       proxmox_ve_password:
         description: "Proxmox VE password for Proxmox Provider"
         required: false
+      cmd_and_ctrl_admin_token:
+        description: "Admin token for cmd_and_ctrl server"
+        required: false
+      cmd_and_ctrl_tunnel_token:
+        description: "Cloudflare Tunnel token for cmd_and_ctrl"
+        required: false
     outputs:
       plan_artifact_name:
         description: "Name of the uploaded plan artifact"
@@ -70,6 +76,8 @@ jobs:
       NODE_OPTIONS: "--no-network-family-autoselection"
       PROXMOX_VE_API_TOKEN: ${{ secrets.proxmox_ve_api_token }}
       PROXMOX_VE_PASSWORD: ${{ secrets.proxmox_ve_password }}
+      TF_VAR_cmd_and_ctrl_admin_token: ${{ secrets.cmd_and_ctrl_admin_token }}
+      TF_VAR_cmd_and_ctrl_tunnel_token: ${{ secrets.cmd_and_ctrl_tunnel_token }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/terraform/deployments/lab/env/lab/terraform.tfvars
+++ b/terraform/deployments/lab/env/lab/terraform.tfvars
@@ -30,6 +30,22 @@ pwnbox = {
   vlan_id        = 200
   admin_username = "krkn"
 }
+cmd_and_ctrl = {
+  name_prefix    = "cmd-and-ctrl"
+  description    = "cmd_and_ctrl game server - Managed by Terraform"
+  tags           = ["cmd-and-ctrl", "gameserver"]
+  bios           = "ovmf"
+  cpu_cores      = 2
+  memory_mb      = 4096
+  os_disk_size   = 40
+  data_disk_size = 20
+  network_bridge = "vmbr0"
+  vlan_id        = 200
+  admin_username = "krkn"
+  fqdn           = "cmd.labxp.io"
+  repo_url       = "https://github.com/krakenhavoc/cmd_and_ctrl.git"
+  repo_ref       = "main"
+}
 windows11 = {
   name_prefix    = "win11"
   description    = "Windows 11 - Managed by Terraform"

--- a/terraform/deployments/lab/env/lab/terraform.tfvars
+++ b/terraform/deployments/lab/env/lab/terraform.tfvars
@@ -43,8 +43,6 @@ cmd_and_ctrl = {
   vlan_id        = 200
   admin_username = "krkn"
   fqdn           = "cmd.labxp.io"
-  repo_url       = "https://github.com/krakenhavoc/cmd_and_ctrl.git"
-  repo_ref       = "main"
 }
 windows11 = {
   name_prefix    = "win11"

--- a/terraform/deployments/lab/main.tf
+++ b/terraform/deployments/lab/main.tf
@@ -69,6 +69,107 @@ module "pwnbox" {
 }
 
 # -----------------------------------------------------------------------------
+# cmd_and_ctrl game server
+# -----------------------------------------------------------------------------
+# Go server + Caddy + Cloudflare Tunnel, behind cmd.labxp.io.
+# Raw resource (not pm-cloudinit-vm module) because it needs a second data disk
+# for CMDCTRL_DATA_DIR (Scryfall dump + image cache).
+
+resource "proxmox_virtual_environment_file" "cmd_and_ctrl_cloudinit" {
+  provider     = pve
+  content_type = "snippets"
+  datastore_id = "snippets"
+  node_name    = var.pve.host
+
+  source_raw {
+    data = templatefile("${path.module}/templates/setup-cmd_and_ctrl.yaml.tftpl", {
+      hostname       = var.cmd_and_ctrl.name_prefix
+      admin_username = var.cmd_and_ctrl.admin_username
+      fqdn           = var.cmd_and_ctrl.fqdn
+      repo_url       = var.cmd_and_ctrl.repo_url
+      repo_ref       = var.cmd_and_ctrl.repo_ref
+      admin_token    = var.cmd_and_ctrl_admin_token
+      tunnel_token   = var.cmd_and_ctrl_tunnel_token
+    })
+    file_name = "setup-${var.cmd_and_ctrl.name_prefix}.yaml"
+  }
+}
+
+resource "proxmox_virtual_environment_vm" "cmd_and_ctrl" {
+  provider = pve
+
+  name        = var.cmd_and_ctrl.name_prefix
+  node_name   = var.pve.host
+  description = var.cmd_and_ctrl.description
+  tags        = sort(concat(["terraform"], var.cmd_and_ctrl.tags))
+  bios        = var.cmd_and_ctrl.bios
+
+  clone {
+    vm_id = data.proxmox_virtual_environment_vms.noble_template.vms[0].vm_id
+    full  = true
+  }
+
+  agent {
+    enabled = true
+    trim    = true
+  }
+
+  cpu {
+    cores = var.cmd_and_ctrl.cpu_cores
+    type  = "x86-64-v2-AES"
+  }
+
+  memory {
+    dedicated = var.cmd_and_ctrl.memory_mb
+  }
+
+  # OS disk (cloned from template)
+  disk {
+    datastore_id = var.vm_disk_datastore_id
+    interface    = "virtio0"
+    iothread     = true
+    discard      = "on"
+    size         = var.cmd_and_ctrl.os_disk_size
+  }
+
+  # Data disk for CMDCTRL_DATA_DIR — Scryfall dump + image cache.
+  # cloud-init formats/mounts at /var/lib/cmd_and_ctrl.
+  disk {
+    datastore_id = var.vm_disk_datastore_id
+    interface    = "virtio1"
+    iothread     = true
+    discard      = "on"
+    size         = var.cmd_and_ctrl.data_disk_size
+    file_format  = "raw"
+  }
+
+  initialization {
+    datastore_id = var.vm_cloudinit_datastore_id
+    ip_config {
+      ipv4 {
+        address = "dhcp"
+      }
+    }
+    user_data_file_id = proxmox_virtual_environment_file.cmd_and_ctrl_cloudinit.id
+  }
+
+  network_device {
+    bridge  = var.cmd_and_ctrl.network_bridge
+    vlan_id = var.cmd_and_ctrl.vlan_id
+  }
+
+  serial_device {}
+
+  vga {
+    type = "std"
+  }
+
+  operating_system {
+    type = "l26"
+  }
+}
+
+# -----------------------------------------------------------------------------
 # Windows 11 VM
 # -----------------------------------------------------------------------------
 # Uses a raw resource instead of the cloud-init module since Windows requires

--- a/terraform/deployments/lab/main.tf
+++ b/terraform/deployments/lab/main.tf
@@ -86,8 +86,6 @@ resource "proxmox_virtual_environment_file" "cmd_and_ctrl_cloudinit" {
       hostname       = var.cmd_and_ctrl.name_prefix
       admin_username = var.cmd_and_ctrl.admin_username
       fqdn           = var.cmd_and_ctrl.fqdn
-      repo_url       = var.cmd_and_ctrl.repo_url
-      repo_ref       = var.cmd_and_ctrl.repo_ref
       admin_token    = var.cmd_and_ctrl_admin_token
       tunnel_token   = var.cmd_and_ctrl_tunnel_token
     })

--- a/terraform/deployments/lab/templates/setup-cmd_and_ctrl.yaml.tftpl
+++ b/terraform/deployments/lab/templates/setup-cmd_and_ctrl.yaml.tftpl
@@ -149,10 +149,13 @@ runcmd:
   - chown -R ${admin_username}:${admin_username} /opt/cmd_and_ctrl
 
   # --- Caddy (official repo) ---
+  # --force-confold is required because write_files already created
+  # /etc/caddy/Caddyfile; without it dpkg hangs on a conffile prompt and
+  # DEBIAN_FRONTEND=noninteractive does not suppress that specific prompt.
   - curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/gpg.key | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
   - curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt | tee /etc/apt/sources.list.d/caddy-stable.list
   - apt-get update
-  - DEBIAN_FRONTEND=noninteractive apt-get install -y caddy
+  - DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::=--force-confold caddy
   - chown -R ${admin_username}:caddy /var/www/cmdctrl-client
   - chmod 0755 /var/www/cmdctrl-client
 

--- a/terraform/deployments/lab/templates/setup-cmd_and_ctrl.yaml.tftpl
+++ b/terraform/deployments/lab/templates/setup-cmd_and_ctrl.yaml.tftpl
@@ -1,4 +1,6 @@
 #cloud-config
+# Host prep only. Application artifacts (server binary, client dist, scripts)
+# are pushed by the cmd_and_ctrl repo's CD pipeline via SSH as ${admin_username}.
 preserve_hostname: false
 hostname: ${hostname}
 ssh_pwauth: false
@@ -7,13 +9,10 @@ package_upgrade: true
 packages:
   - qemu-guest-agent
   - curl
-  - git
-  - make
   - ca-certificates
-  - debian-keyring
-  - debian-archive-keyring
   - apt-transport-https
   - gnupg
+  - rsync
 
 users:
   - name: ${admin_username}
@@ -26,13 +25,15 @@ users:
   - name: cmdctrl
     system: true
     shell: /usr/sbin/nologin
-    home: /var/lib/cmd_and_ctrl
+    homedir: /var/lib/cmd_and_ctrl
+    no_create_home: true
 
 write_files:
-  # Env file for the server (root:cmdctrl 0640)
+  # Env file for the server. Created root:root first; chowned to root:cmdctrl
+  # in runcmd after the cmdctrl user exists.
   - path: /etc/cmd_and_ctrl/env
     permissions: "0640"
-    owner: root:cmdctrl
+    owner: root:root
     content: |
       CMDCTRL_ADMIN_TOKEN=${admin_token}
       CMDCTRL_ADDR=127.0.0.1:8080
@@ -140,20 +141,20 @@ runcmd:
     mkdir -p /var/lib/cmd_and_ctrl/data/scryfall /var/lib/cmd_and_ctrl/data/images
     chown -R cmdctrl:cmdctrl /var/lib/cmd_and_ctrl
 
-  # --- Toolchain: Go 1.23, Node 22 ---
-  - curl -fsSL https://go.dev/dl/go1.23.5.linux-amd64.tar.gz -o /tmp/go.tar.gz
-  - rm -rf /usr/local/go && tar -C /usr/local -xzf /tmp/go.tar.gz
-  - rm /tmp/go.tar.gz
-  - ln -sf /usr/local/go/bin/go /usr/local/bin/go
-  - curl -fsSL https://nodejs.org/dist/v22.12.0/node-v22.12.0-linux-x64.tar.xz -o /tmp/node.tar.xz
-  - tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1
-  - rm /tmp/node.tar.xz
+  # --- Fix env file ownership now that cmdctrl user exists ---
+  - chown root:cmdctrl /etc/cmd_and_ctrl/env
+
+  # --- CD-writable paths. ${admin_username} rsyncs artifacts here. ---
+  - mkdir -p /opt/cmd_and_ctrl/server/bin /opt/cmd_and_ctrl/scripts /var/www/cmdctrl-client
+  - chown -R ${admin_username}:${admin_username} /opt/cmd_and_ctrl
 
   # --- Caddy (official repo) ---
   - curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/gpg.key | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
   - curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt | tee /etc/apt/sources.list.d/caddy-stable.list
   - apt-get update
   - DEBIAN_FRONTEND=noninteractive apt-get install -y caddy
+  - chown -R ${admin_username}:caddy /var/www/cmdctrl-client
+  - chmod 0755 /var/www/cmdctrl-client
 
   # --- cloudflared (official repo) ---
   - curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
@@ -161,20 +162,12 @@ runcmd:
   - apt-get update
   - DEBIAN_FRONTEND=noninteractive apt-get install -y cloudflared
 
-  # --- Clone and build cmd_and_ctrl ---
-  - git clone -b ${repo_ref} ${repo_url} /opt/cmd_and_ctrl
-  - cd /opt/cmd_and_ctrl/server && CGO_ENABLED=0 /usr/local/bin/go build -trimpath -ldflags="-s -w" -o bin/cmd_and_ctrl-server ./cmd/server
-  - cd /opt/cmd_and_ctrl/client && /usr/local/bin/npm install && /usr/local/bin/npm run build
-  - mkdir -p /var/www/cmdctrl-client
-  - cp -r /opt/cmd_and_ctrl/client/dist/. /var/www/cmdctrl-client/
-  - chown -R cmdctrl:cmdctrl /opt/cmd_and_ctrl
-  - chown -R caddy:caddy /var/www/cmdctrl-client
-  - chmod +x /opt/cmd_and_ctrl/scripts/scryfall-refresh.sh || true
-
   # --- Enable services ---
+  # cmd-and-ctrl.service and the scryfall timer will fail until CD pushes the
+  # binary and script. Restart=on-failure handles the retry loop.
   - systemctl daemon-reload
   - systemctl enable --now caddy
-  - systemctl enable --now cmd-and-ctrl.service
+  - systemctl enable cmd-and-ctrl.service
   - systemctl enable --now cmd-and-ctrl-scryfall.timer
   - cloudflared service install ${tunnel_token}
 
@@ -185,9 +178,10 @@ power_state:
   condition: true
 
 final_message: |
-  ${hostname} is up. Go server on 127.0.0.1:8080, Caddy on :80, cloudflared connector registered.
-  Manual post-config in Cloudflare Zero Trust dashboard:
-    Networks > Tunnels > <this tunnel> > Public Hostname > Add:
-      Hostname: ${fqdn}
-      Service:  http://localhost:80
-  (DNS CNAME is created automatically by the dashboard.)
+  ${hostname} host is ready. Caddy on :80, cloudflared connector registered.
+  Deploy artifacts from cmd_and_ctrl CD pipeline:
+    rsync server binary to /opt/cmd_and_ctrl/server/bin/cmd_and_ctrl-server
+    rsync client dist/ to /var/www/cmdctrl-client/
+    rsync scripts/ to /opt/cmd_and_ctrl/scripts/
+    sudo systemctl restart cmd-and-ctrl
+  One-time: add public hostname ${fqdn} -> http://localhost:80 in CF Zero Trust dashboard.

--- a/terraform/deployments/lab/templates/setup-cmd_and_ctrl.yaml.tftpl
+++ b/terraform/deployments/lab/templates/setup-cmd_and_ctrl.yaml.tftpl
@@ -126,8 +126,9 @@ write_files:
 runcmd:
   # --- Data disk: format + mount at /var/lib/cmd_and_ctrl ---
   # OS disk is virtio0 (/dev/vda), data disk is virtio1 (/dev/vdb).
+  # Runs under /bin/sh (dash on Ubuntu) — no bash-only flags like `pipefail`.
   - |
-    set -euo pipefail
+    set -eu
     DATA_DEV=/dev/vdb
     if ! blkid "$DATA_DEV" >/dev/null 2>&1; then
       mkfs.ext4 -L cmdctrl-data "$DATA_DEV"

--- a/terraform/deployments/lab/templates/setup-cmd_and_ctrl.yaml.tftpl
+++ b/terraform/deployments/lab/templates/setup-cmd_and_ctrl.yaml.tftpl
@@ -1,0 +1,192 @@
+#cloud-config
+preserve_hostname: false
+hostname: ${hostname}
+ssh_pwauth: false
+package_update: true
+package_upgrade: true
+packages:
+  - qemu-guest-agent
+  - curl
+  - git
+  - make
+  - ca-certificates
+  - debian-keyring
+  - debian-archive-keyring
+  - apt-transport-https
+  - gnupg
+
+users:
+  - name: ${admin_username}
+    gecos: "cmd_and_ctrl Admin"
+    groups: sudo
+    shell: /bin/bash
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILZzMMk21CqtHkvN3b0euByxFNR042KCcot981yCwUlu
+  - name: cmdctrl
+    system: true
+    shell: /usr/sbin/nologin
+    home: /var/lib/cmd_and_ctrl
+
+write_files:
+  # Env file for the server (root:cmdctrl 0640)
+  - path: /etc/cmd_and_ctrl/env
+    permissions: "0640"
+    owner: root:cmdctrl
+    content: |
+      CMDCTRL_ADMIN_TOKEN=${admin_token}
+      CMDCTRL_ADDR=127.0.0.1:8080
+      CMDCTRL_DATA_DIR=/var/lib/cmd_and_ctrl/data
+      CMDCTRL_ALLOWED_ORIGINS=${fqdn}
+
+  # Caddyfile — static client + reverse proxy to Go server.
+  # HTTP-only: Cloudflare Tunnel terminates TLS at the edge and forwards
+  # plain HTTP to this origin, so Caddy does not need its own cert.
+  - path: /etc/caddy/Caddyfile
+    permissions: "0644"
+    owner: root:root
+    content: |
+      {
+        admin off
+        auto_https off
+      }
+
+      :80 {
+        encode zstd gzip
+        root * /var/www/cmdctrl-client
+        file_server
+        reverse_proxy /ws        127.0.0.1:8080
+        reverse_proxy /healthz   127.0.0.1:8080
+        reverse_proxy /games*    127.0.0.1:8080
+        reverse_proxy /cards/*   127.0.0.1:8080
+        reverse_proxy /admin/*   127.0.0.1:8080
+        reverse_proxy /me        127.0.0.1:8080
+      }
+
+  # systemd unit — Go server
+  - path: /etc/systemd/system/cmd-and-ctrl.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=cmd_and_ctrl game server
+      After=network-online.target var-lib-cmd_and_ctrl.mount
+      Wants=network-online.target
+      RequiresMountsFor=/var/lib/cmd_and_ctrl
+
+      [Service]
+      Type=simple
+      User=cmdctrl
+      Group=cmdctrl
+      WorkingDirectory=/opt/cmd_and_ctrl/server
+      EnvironmentFile=/etc/cmd_and_ctrl/env
+      ExecStart=/opt/cmd_and_ctrl/server/bin/cmd_and_ctrl-server
+      Restart=on-failure
+      RestartSec=5
+      TimeoutStopSec=30
+      SuccessExitStatus=0 143
+      NoNewPrivileges=true
+      ProtectSystem=strict
+      ProtectHome=true
+      PrivateTmp=true
+      ReadWritePaths=/var/lib/cmd_and_ctrl
+
+      [Install]
+      WantedBy=multi-user.target
+
+  # systemd unit + timer — weekly Scryfall dump refresh
+  - path: /etc/systemd/system/cmd-and-ctrl-scryfall.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=Refresh Scryfall card dump for cmd_and_ctrl
+      After=network-online.target
+      Wants=network-online.target
+
+      [Service]
+      Type=oneshot
+      User=cmdctrl
+      Group=cmdctrl
+      EnvironmentFile=/etc/cmd_and_ctrl/env
+      ExecStart=/opt/cmd_and_ctrl/scripts/scryfall-refresh.sh
+  - path: /etc/systemd/system/cmd-and-ctrl-scryfall.timer
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=Weekly Scryfall dump refresh for cmd_and_ctrl
+
+      [Timer]
+      OnCalendar=Sun 05:00
+      OnBootSec=15min
+      Persistent=true
+      Unit=cmd-and-ctrl-scryfall.service
+
+      [Install]
+      WantedBy=timers.target
+
+runcmd:
+  # --- Data disk: format + mount at /var/lib/cmd_and_ctrl ---
+  # OS disk is virtio0 (/dev/vda), data disk is virtio1 (/dev/vdb).
+  - |
+    set -euo pipefail
+    DATA_DEV=/dev/vdb
+    if ! blkid "$DATA_DEV" >/dev/null 2>&1; then
+      mkfs.ext4 -L cmdctrl-data "$DATA_DEV"
+    fi
+    mkdir -p /var/lib/cmd_and_ctrl
+    UUID=$(blkid -s UUID -o value "$DATA_DEV")
+    grep -q "$UUID" /etc/fstab || echo "UUID=$UUID /var/lib/cmd_and_ctrl ext4 defaults,noatime 0 2" >> /etc/fstab
+    mount -a
+    mkdir -p /var/lib/cmd_and_ctrl/data/scryfall /var/lib/cmd_and_ctrl/data/images
+    chown -R cmdctrl:cmdctrl /var/lib/cmd_and_ctrl
+
+  # --- Toolchain: Go 1.23, Node 22 ---
+  - curl -fsSL https://go.dev/dl/go1.23.5.linux-amd64.tar.gz -o /tmp/go.tar.gz
+  - rm -rf /usr/local/go && tar -C /usr/local -xzf /tmp/go.tar.gz
+  - rm /tmp/go.tar.gz
+  - ln -sf /usr/local/go/bin/go /usr/local/bin/go
+  - curl -fsSL https://nodejs.org/dist/v22.12.0/node-v22.12.0-linux-x64.tar.xz -o /tmp/node.tar.xz
+  - tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1
+  - rm /tmp/node.tar.xz
+
+  # --- Caddy (official repo) ---
+  - curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/gpg.key | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+  - curl -fsSL https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt | tee /etc/apt/sources.list.d/caddy-stable.list
+  - apt-get update
+  - DEBIAN_FRONTEND=noninteractive apt-get install -y caddy
+
+  # --- cloudflared (official repo) ---
+  - curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
+  - echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared noble main" > /etc/apt/sources.list.d/cloudflared.list
+  - apt-get update
+  - DEBIAN_FRONTEND=noninteractive apt-get install -y cloudflared
+
+  # --- Clone and build cmd_and_ctrl ---
+  - git clone -b ${repo_ref} ${repo_url} /opt/cmd_and_ctrl
+  - cd /opt/cmd_and_ctrl/server && CGO_ENABLED=0 /usr/local/bin/go build -trimpath -ldflags="-s -w" -o bin/cmd_and_ctrl-server ./cmd/server
+  - cd /opt/cmd_and_ctrl/client && /usr/local/bin/npm install && /usr/local/bin/npm run build
+  - mkdir -p /var/www/cmdctrl-client
+  - cp -r /opt/cmd_and_ctrl/client/dist/. /var/www/cmdctrl-client/
+  - chown -R cmdctrl:cmdctrl /opt/cmd_and_ctrl
+  - chown -R caddy:caddy /var/www/cmdctrl-client
+  - chmod +x /opt/cmd_and_ctrl/scripts/scryfall-refresh.sh || true
+
+  # --- Enable services ---
+  - systemctl daemon-reload
+  - systemctl enable --now caddy
+  - systemctl enable --now cmd-and-ctrl.service
+  - systemctl enable --now cmd-and-ctrl-scryfall.timer
+  - cloudflared service install ${tunnel_token}
+
+power_state:
+  mode: reboot
+  message: "Rebooting after cloud-init final stage"
+  timeout: 30
+  condition: true
+
+final_message: |
+  ${hostname} is up. Go server on 127.0.0.1:8080, Caddy on :80, cloudflared connector registered.
+  Manual post-config in Cloudflare Zero Trust dashboard:
+    Networks > Tunnels > <this tunnel> > Public Hostname > Add:
+      Hostname: ${fqdn}
+      Service:  http://localhost:80
+  (DNS CNAME is created automatically by the dashboard.)

--- a/terraform/deployments/lab/variables.tf
+++ b/terraform/deployments/lab/variables.tf
@@ -73,8 +73,6 @@ variable "cmd_and_ctrl" {
     vlan_id        = optional(number, 200)
     admin_username = optional(string, "krkn")
     fqdn           = optional(string, "cmd.labxp.io")
-    repo_url       = optional(string, "https://github.com/krakenhavoc/cmd_and_ctrl.git")
-    repo_ref       = optional(string, "main")
   })
   default = {}
 }

--- a/terraform/deployments/lab/variables.tf
+++ b/terraform/deployments/lab/variables.tf
@@ -58,6 +58,39 @@ variable "pwnbox" {
   default = {}
 }
 
+variable "cmd_and_ctrl" {
+  description = "Object containing the cmd_and_ctrl game server configuration"
+  type = object({
+    name_prefix    = optional(string, "cmd-and-ctrl")
+    description    = optional(string, "cmd_and_ctrl game server - Managed by Terraform")
+    tags           = optional(list(string), ["cmd-and-ctrl", "gameserver"])
+    bios           = optional(string, "ovmf")
+    cpu_cores      = optional(number, 2)
+    memory_mb      = optional(number, 4096)
+    os_disk_size   = optional(number, 40)
+    data_disk_size = optional(number, 20)
+    network_bridge = optional(string, "vmbr0")
+    vlan_id        = optional(number, 200)
+    admin_username = optional(string, "krkn")
+    fqdn           = optional(string, "cmd.labxp.io")
+    repo_url       = optional(string, "https://github.com/krakenhavoc/cmd_and_ctrl.git")
+    repo_ref       = optional(string, "main")
+  })
+  default = {}
+}
+
+variable "cmd_and_ctrl_admin_token" {
+  description = "Admin token for cmd_and_ctrl server (CMDCTRL_ADMIN_TOKEN). 16+ chars."
+  type        = string
+  sensitive   = true
+}
+
+variable "cmd_and_ctrl_tunnel_token" {
+  description = "Cloudflare Tunnel token for cmd.labxp.io. Generated in Cloudflare Zero Trust dashboard."
+  type        = string
+  sensitive   = true
+}
+
 variable "windows11" {
   description = "Object containing the Windows 11 VM configuration"
   type = object({


### PR DESCRIPTION
This pull request adds a new infrastructure resource for a "cmd_and_ctrl" game server to the Terraform configuration for the lab environment. The change introduces a new VM with its own configuration, cloud-init setup, and supporting variables, enabling automated provisioning, setup, and management of the game server, including its dependencies and scheduled tasks.

**New "cmd_and_ctrl" Game Server Infrastructure**

* Added a new `cmd_and_ctrl` VM configuration block in `terraform.tfvars`, specifying details such as resources, network, disks, and repository info.
* Introduced new Terraform variables for `cmd_and_ctrl` configuration and sensitive tokens in `variables.tf`, allowing customization and secure handling of admin and tunnel tokens.

**Provisioning and Automation**

* Defined new Terraform resources in `main.tf` to provision the `cmd_and_ctrl` VM, including a custom cloud-init file, data disk setup, and required tags. The VM is provisioned from a template and includes a second disk for persistent data.
* Added a cloud-init template (`setup-cmd_and_ctrl.yaml.tftpl`) that automates user creation, environment setup, package installation (Go, Node, Caddy, cloudflared), cloning and building the server/client, service enablement, and data disk formatting/mounting. It also sets up scheduled jobs for Scryfall data refresh.
