### PR TITLE
feat: seed cmd_and_ctrl bug-report PAT via cloud-init (TF_VAR wiring)

### DIFF
--- a/.github/workflows/lab-deploy.yaml
+++ b/.github/workflows/lab-deploy.yaml
@@ -40,6 +40,7 @@ jobs:
       proxmox_ve_api_token: ${{ secrets.PROXMOX_VE_API_TOKEN }}
       cmd_and_ctrl_admin_token: ${{ secrets.CMD_AND_CTRL_ADMIN_TOKEN }}
       cmd_and_ctrl_tunnel_token: ${{ secrets.CMD_AND_CTRL_TUNNEL_TOKEN }}
+      cmd_and_ctrl_github_token: ${{ secrets.CMD_AND_CTRL_GITHUB_TOKEN }}
 
   lab-cd:
     needs: lab-ci

--- a/.github/workflows/terraform-ci.yaml
+++ b/.github/workflows/terraform-ci.yaml
@@ -56,6 +56,9 @@ on:
       cmd_and_ctrl_tunnel_token:
         description: "Cloudflare Tunnel token for cmd_and_ctrl"
         required: false
+      cmd_and_ctrl_github_token:
+        description: "GitHub PAT for the cmd_and_ctrl in-app bug-report button (cloud-init seed)"
+        required: false
     outputs:
       plan_artifact_name:
         description: "Name of the uploaded plan artifact"
@@ -78,6 +81,7 @@ jobs:
       PROXMOX_VE_PASSWORD: ${{ secrets.proxmox_ve_password }}
       TF_VAR_cmd_and_ctrl_admin_token: ${{ secrets.cmd_and_ctrl_admin_token }}
       TF_VAR_cmd_and_ctrl_tunnel_token: ${{ secrets.cmd_and_ctrl_tunnel_token }}
+      TF_VAR_cmd_and_ctrl_github_token: ${{ secrets.cmd_and_ctrl_github_token }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/terraform/deployments/lab/env/lab/terraform.tfvars
+++ b/terraform/deployments/lab/env/lab/terraform.tfvars
@@ -11,7 +11,9 @@ openclaw = {
   bios           = "ovmf"
   cpu_cores      = 4
   memory_mb      = 16384
-  os_disk_size   = 50
+  # Matches the disk's real size — it was grown to 100G out-of-band
+  # and the config had drifted at 50.
+  os_disk_size   = 100
   disk_interface = "virtio0"
   network_bridge = "vmbr0"
   vlan_id        = 200

--- a/terraform/deployments/lab/main.tf
+++ b/terraform/deployments/lab/main.tf
@@ -88,6 +88,7 @@ resource "proxmox_virtual_environment_file" "cmd_and_ctrl_cloudinit" {
       fqdn           = var.cmd_and_ctrl.fqdn
       admin_token    = var.cmd_and_ctrl_admin_token
       tunnel_token   = var.cmd_and_ctrl_tunnel_token
+      github_token   = var.cmd_and_ctrl_github_token
     })
     file_name = "setup-${var.cmd_and_ctrl.name_prefix}.yaml"
   }

--- a/terraform/deployments/lab/templates/setup-cmd_and_ctrl.yaml.tftpl
+++ b/terraform/deployments/lab/templates/setup-cmd_and_ctrl.yaml.tftpl
@@ -38,7 +38,8 @@ write_files:
       CMDCTRL_ADMIN_TOKEN=${admin_token}
       CMDCTRL_ADDR=127.0.0.1:8080
       CMDCTRL_DATA_DIR=/var/lib/cmd_and_ctrl/data
-      CMDCTRL_ALLOWED_ORIGINS=${fqdn}
+      CMDCTRL_ALLOWED_ORIGINS=${fqdn}%{ if github_token != "" }
+      CMDCTRL_GITHUB_TOKEN=${github_token}%{ endif }
 
   # Caddyfile — static client + reverse proxy to Go server.
   # HTTP-only: Cloudflare Tunnel terminates TLS at the edge and forwards

--- a/terraform/deployments/lab/variables.tf
+++ b/terraform/deployments/lab/variables.tf
@@ -89,6 +89,24 @@ variable "cmd_and_ctrl_tunnel_token" {
   sensitive   = true
 }
 
+variable "cmd_and_ctrl_github_token" {
+  description = <<-EOT
+    Fine-grained GitHub PAT for the in-app bug-report button (cmd_and_ctrl
+    ADR 0017): Issues:write on krakenhavoc/cmd_and_ctrl only. Seeds the
+    first-boot env file in the cloud-init template so a rebuilt VM starts
+    with bug reporting live. Flows in as TF_VAR_cmd_and_ctrl_github_token
+    from the CMD_AND_CTRL_GITHUB_TOKEN environment secret (lab), same as
+    the admin/tunnel tokens. The steady-state copy on the host is synced
+    by the cmd_and_ctrl repo's CD pipeline from that repo's own
+    CMDCTRL_GITHUB_TOKEN Actions secret (managed by hand — deliberately
+    not Terraform; one secret didn't justify a github-provider
+    credential). Empty string (the default) writes no env line.
+  EOT
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "windows11" {
   description = "Object containing the Windows 11 VM configuration"
   type = object({


### PR DESCRIPTION
New sensitive variable cmd_and_ctrl_github_token adds an optional CMDCTRL_GITHUB_TOKEN line to the game server's cloud-init env file, so a rebuilt VM boots with the in-app bug-report feature live (cmd_and_ctrl ADR 0017). Wired through the existing secret path: CMD_AND_CTRL_GITHUB_TOKEN environment secret (lab) -> lab-deploy -> terraform-ci TF_VAR, exactly like the admin/tunnel tokens. The steady-state host copy is synced by the cmd_and_ctrl repo's own CD from that repo's CMDCTRL_GITHUB_TOKEN Actions secret, which stays hand-managed: a Terraform github provider (and its credential) wasn't justified for one secret. Empty variable (default) is a verified no-op — rendered cloud-init is byte-identical to HEAD.

Hook-equivalents run out-of-band (sandbox couldn't exec the hl-venv interpreter): terraform fmt/validate/tflint clean, trivy config scan 0 findings, workflow YAML parses. CI pre-commit re-checks on the PR.